### PR TITLE
Change height of transcript divs in videos.module.css

### DIFF
--- a/pages/videos/videos.module.css
+++ b/pages/videos/videos.module.css
@@ -469,7 +469,7 @@
     padding: 5px 10px;
     display: flex;
     flex-direction: row;
-    height: 30px;
+    height: fit-content;
     opacity: 0.75;
     width: 500px;
 }


### PR DESCRIPTION
I would change the height of the transcript div to 'fit-content' so that the transcripts can take up as much room height wise as they need and not go out of the area they have.

Before 
![Before](https://github.com/AltriusRS/wandb/assets/61364477/f5ac9ec9-01ea-4e6f-8823-d795e42d7480)
After:
![After](https://github.com/AltriusRS/wandb/assets/61364477/29464a93-722b-41e0-9871-30940f8174a3)
